### PR TITLE
Update REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,2 @@
 julia 0.7
 BinDeps
-Libdl


### PR DESCRIPTION
METADATA PR https://github.com/JuliaLang/METADATA.jl/pull/19963 is failing because of `Libdl` in REQUIRE, see https://travis-ci.org/JuliaLang/METADATA.jl/jobs/465665082.  Remove it.