### PR TITLE
Add generator files. Wrap latest 1.9 release.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LibSpatialIndex"
 uuid = "f19c2e90-9d16-5f2d-a2a7-af3fb29e4907"
 license = "MIT"
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 GeoInterface = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
@@ -10,7 +10,7 @@ LibSpatialIndex_jll = "00e98e2a-4326-5239-88cb-15dcbe1c18d0"
 [compat]
 Aqua = "0.7"
 GeoInterface = "1"
-LibSpatialIndex_jll = "1.8"
+LibSpatialIndex_jll = "~1.9"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ LibSpatialIndex_jll = "00e98e2a-4326-5239-88cb-15dcbe1c18d0"
 [compat]
 Aqua = "0.7"
 GeoInterface = "1"
-LibSpatialIndex_jll = "~1.9"
+LibSpatialIndex_jll = "1.9"
 julia = "1.6"
 
 [extras]

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+Clang = "40e3b903-d033-50b4-a0cc-940c62c95e31"
+LibSpatialIndex_jll = "00e98e2a-4326-5239-88cb-15dcbe1c18d0"

--- a/gen/README.md
+++ b/gen/README.md
@@ -1,0 +1,6 @@
+LibSpatialIndex.jl generation documentation
+================================
+
+### Run the wrapping scripts
+1. Run `julia --project` in this directory and `pkg> instantiate` the dependencies.
+2. Run `include("generator.jl")` to generate the wrapping.

--- a/gen/generator.jl
+++ b/gen/generator.jl
@@ -1,0 +1,26 @@
+using Clang
+using Clang.Generators
+using LibSpatialIndex_jll
+
+# several functions for building docstrings
+includedir = joinpath(LibSpatialIndex_jll.artifact_dir, "include/spatialindex/capi")
+headerfiles = joinpath.(includedir, ["sidx_api.h", "sidx_config.h"])
+for headerfile in headerfiles
+    if !isfile(headerfile)
+        error("Header file missing `($headerfile)")
+    end
+end
+
+options = load_options(joinpath(@__DIR__, "generator.toml"))
+
+# add compiler flags, e.g. "-DXXXXXXXXX"
+args = get_default_args()
+push!(args, "-I$includedir")
+
+# create context
+ctx = create_context(headerfiles, args, options)
+
+# run generator
+build!(ctx)
+
+close(loghandle)

--- a/gen/generator.jl
+++ b/gen/generator.jl
@@ -22,5 +22,3 @@ ctx = create_context(headerfiles, args, options)
 
 # run generator
 build!(ctx)
-
-close(loghandle)

--- a/gen/generator.toml
+++ b/gen/generator.toml
@@ -1,0 +1,29 @@
+[general]
+library_name = "libspatialindex_c"
+# jll_pkg_name = "LibSpatialIndex_jll"
+output_api_file_path = "../src/include/sidx_api.jl"
+output_common_file_path = "../src/include/sidx_config.jl"
+print_using_CEnum = true
+use_julia_native_enum_type = true
+output_ignorelist = ["SIDX_C_API", "SIDX_THREAD", "STRDUP"]
+use_deterministic_symbol = true
+smart_de_anonymize = true
+extract_c_comment_style = "doxygen"
+fold_single_line_comment = true
+struct_field_comment_style = "outofline"
+enumerator_comment_style = "outofline"
+show_c_function_prototype = false
+
+[codegen]
+is_function_strictly_typed = false
+use_julia_bool = true
+always_NUL_terminated_string = true
+opaque_func_arg_as_PtrCvoid = false
+opaque_as_mutable_struct = false
+
+[codegen.macro]
+macro_mode = "basic"
+add_comment_for_skipped_macro = true
+ignore_header_guards = true
+ignore_header_guards_with_suffixes = []
+ignore_pure_definition = true

--- a/gen/generator.toml
+++ b/gen/generator.toml
@@ -1,6 +1,5 @@
 [general]
 library_name = "libspatialindex_c"
-# jll_pkg_name = "LibSpatialIndex_jll"
 output_api_file_path = "../src/include/sidx_api.jl"
 output_common_file_path = "../src/include/sidx_config.jl"
 print_using_CEnum = true
@@ -15,6 +14,7 @@ enumerator_comment_style = "outofline"
 show_c_function_prototype = false
 
 [codegen]
+use_ccall_macro = true
 is_function_strictly_typed = false
 use_julia_bool = true
 always_NUL_terminated_string = true

--- a/src/include/sidx_api.jl
+++ b/src/include/sidx_api.jl
@@ -1,164 +1,176 @@
-# Julia wrapper for header: /Users/yeesian/Downloads/libspatialindex_c-master/include/spatialindex/capi/sidx_api.h
-# Automatically generated using Clang.jl wrap_c, version 0.0.0
-
-
-function Index_Create(properties::IndexPropertyH)
+function Index_Create(properties)
     ccall((:Index_Create, libspatialindex_c), IndexH, (IndexPropertyH,), properties)
 end
 
-function Index_CreateWithStream(properties::IndexPropertyH, readNext)
-    ccall((:Index_CreateWithStream, libspatialindex_c), IndexH, (IndexPropertyH, Ptr{Nothing}), properties, readNext)
+function Index_CreateWithStream(properties, readNext)
+    ccall((:Index_CreateWithStream, libspatialindex_c), IndexH, (IndexPropertyH, Ptr{Cvoid}), properties, readNext)
 end
 
-function Index_Destroy(index::IndexH)
-    ccall((:Index_Destroy, libspatialindex_c), Nothing, (IndexH,), index)
+function Index_Destroy(index)
+    ccall((:Index_Destroy, libspatialindex_c), Cvoid, (IndexH,), index)
 end
 
-function Index_GetProperties(index::IndexH)
+function Index_GetProperties(index)
     ccall((:Index_GetProperties, libspatialindex_c), IndexPropertyH, (IndexH,), index)
 end
 
-function Index_DeleteData(index::IndexH, id::Integer, pdMin, pdMax, nDimension::Integer)
+function Index_DeleteData(index, id, pdMin, pdMax, nDimension)
     ccall((:Index_DeleteData, libspatialindex_c), RTError, (IndexH, Int64, Ptr{Cdouble}, Ptr{Cdouble}, UInt32), index, id, pdMin, pdMax, nDimension)
 end
 
-function Index_DeleteTPData(index::IndexH, id::Integer, pdMin, pdMax, pdVMin, pdVMax, tStart::Cdouble, tEnd::Cdouble, nDimension::Integer)
+function Index_DeleteTPData(index, id, pdMin, pdMax, pdVMin, pdVMax, tStart, tEnd, nDimension)
     ccall((:Index_DeleteTPData, libspatialindex_c), RTError, (IndexH, Int64, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Cdouble, Cdouble, UInt32), index, id, pdMin, pdMax, pdVMin, pdVMax, tStart, tEnd, nDimension)
 end
 
-function Index_DeleteMVRData(index::IndexH, id::Integer, pdMin, pdMax, tStart::Cdouble, tEnd::Cdouble, nDimension::Integer)
+function Index_DeleteMVRData(index, id, pdMin, pdMax, tStart, tEnd, nDimension)
     ccall((:Index_DeleteMVRData, libspatialindex_c), RTError, (IndexH, Int64, Ptr{Cdouble}, Ptr{Cdouble}, Cdouble, Cdouble, UInt32), index, id, pdMin, pdMax, tStart, tEnd, nDimension)
 end
 
-function Index_InsertData(index::IndexH, id::Integer, pdMin, pdMax, nDimension::Integer, pData, nDataLength::Integer)
+function Index_InsertData(index, id, pdMin, pdMax, nDimension, pData, nDataLength)
     ccall((:Index_InsertData, libspatialindex_c), RTError, (IndexH, Int64, Ptr{Cdouble}, Ptr{Cdouble}, UInt32, Ptr{UInt8}, Cint), index, id, pdMin, pdMax, nDimension, pData, nDataLength)
 end
 
-function Index_InsertTPData(index::IndexH, id::Integer, pdMin, pdMax, pdVMin, pdVMax, tStart::Cdouble, tEnd::Cdouble, nDimension::Integer, pData, nDataLength::Integer)
+function Index_InsertTPData(index, id, pdMin, pdMax, pdVMin, pdVMax, tStart, tEnd, nDimension, pData, nDataLength)
     ccall((:Index_InsertTPData, libspatialindex_c), RTError, (IndexH, Int64, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Cdouble, Cdouble, UInt32, Ptr{UInt8}, Cint), index, id, pdMin, pdMax, pdVMin, pdVMax, tStart, tEnd, nDimension, pData, nDataLength)
 end
 
-function Index_InsertMVRData(index::IndexH, id::Integer, pdMin, pdMax, tStart::Cdouble, tEnd::Cdouble, nDimension::Integer, pData, nDataLength::Integer)
+function Index_InsertMVRData(index, id, pdMin, pdMax, tStart, tEnd, nDimension, pData, nDataLength)
     ccall((:Index_InsertMVRData, libspatialindex_c), RTError, (IndexH, Int64, Ptr{Cdouble}, Ptr{Cdouble}, Cdouble, Cdouble, UInt32, Ptr{UInt8}, Cint), index, id, pdMin, pdMax, tStart, tEnd, nDimension, pData, nDataLength)
 end
 
-function Index_IsValid(index::IndexH)
+function Index_IsValid(index)
     ccall((:Index_IsValid, libspatialindex_c), UInt32, (IndexH,), index)
 end
 
-function Index_TPIntersects_obj(index::IndexH, pdMin, pdMax, pdVMin, pdVMax, tStart::Cdouble, tEnd::Cdouble, nDimension::Integer, items, nResults)
+function Index_TPIntersects_obj(index, pdMin, pdMax, pdVMin, pdVMax, tStart, tEnd, nDimension, items, nResults)
     ccall((:Index_TPIntersects_obj, libspatialindex_c), RTError, (IndexH, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Cdouble, Cdouble, UInt32, Ptr{Ptr{IndexItemH}}, Ptr{UInt64}), index, pdMin, pdMax, pdVMin, pdVMax, tStart, tEnd, nDimension, items, nResults)
 end
 
-function Index_MVRIntersects_obj(index::IndexH, pdMin, pdMax, tStart::Cdouble, tEnd::Cdouble, nDimension::Integer, items, nResults)
+function Index_MVRIntersects_obj(index, pdMin, pdMax, tStart, tEnd, nDimension, items, nResults)
     ccall((:Index_MVRIntersects_obj, libspatialindex_c), RTError, (IndexH, Ptr{Cdouble}, Ptr{Cdouble}, Cdouble, Cdouble, UInt32, Ptr{Ptr{IndexItemH}}, Ptr{UInt64}), index, pdMin, pdMax, tStart, tEnd, nDimension, items, nResults)
 end
 
-function Index_Intersects_obj(index::IndexH, pdMin, pdMax, nDimension::Integer, items, nResults)
+function Index_Intersects_obj(index, pdMin, pdMax, nDimension, items, nResults)
     ccall((:Index_Intersects_obj, libspatialindex_c), RTError, (IndexH, Ptr{Cdouble}, Ptr{Cdouble}, UInt32, Ptr{Ptr{IndexItemH}}, Ptr{UInt64}), index, pdMin, pdMax, nDimension, items, nResults)
 end
 
-function Index_TPIntersects_id(index::IndexH, pdMin, pdMax, pdVMin, pdVMax, tStart::Cdouble, tEnd::Cdouble, nDimension::Integer, ids, nResults)
+function Index_Contains_obj(index, pdMin, pdMax, nDimension, items, nResults)
+    ccall((:Index_Contains_obj, libspatialindex_c), RTError, (IndexH, Ptr{Cdouble}, Ptr{Cdouble}, UInt32, Ptr{Ptr{IndexItemH}}, Ptr{UInt64}), index, pdMin, pdMax, nDimension, items, nResults)
+end
+
+function Index_TPIntersects_id(index, pdMin, pdMax, pdVMin, pdVMax, tStart, tEnd, nDimension, ids, nResults)
     ccall((:Index_TPIntersects_id, libspatialindex_c), RTError, (IndexH, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Cdouble, Cdouble, UInt32, Ptr{Ptr{Int64}}, Ptr{UInt64}), index, pdMin, pdMax, pdVMin, pdVMax, tStart, tEnd, nDimension, ids, nResults)
 end
 
-function Index_MVRIntersects_id(index::IndexH, pdMin, pdMax, tStart::Cdouble, tEnd::Cdouble, nDimension::Integer, ids, nResults)
+function Index_MVRIntersects_id(index, pdMin, pdMax, tStart, tEnd, nDimension, ids, nResults)
     ccall((:Index_MVRIntersects_id, libspatialindex_c), RTError, (IndexH, Ptr{Cdouble}, Ptr{Cdouble}, Cdouble, Cdouble, UInt32, Ptr{Ptr{Int64}}, Ptr{UInt64}), index, pdMin, pdMax, tStart, tEnd, nDimension, ids, nResults)
 end
 
-function Index_Intersects_id(index::IndexH, pdMin, pdMax, nDimension::Integer, items, nResults)
+function Index_Intersects_id(index, pdMin, pdMax, nDimension, items, nResults)
     ccall((:Index_Intersects_id, libspatialindex_c), RTError, (IndexH, Ptr{Cdouble}, Ptr{Cdouble}, UInt32, Ptr{Ptr{Int64}}, Ptr{UInt64}), index, pdMin, pdMax, nDimension, items, nResults)
 end
 
-function Index_TPIntersects_count(index::IndexH, pdMin, pdMax, pdVMin, pdVMax, tStart::Cdouble, tEnd::Cdouble, nDimension::Integer, nResults)
+function Index_Contains_id(index, pdMin, pdMax, nDimension, ids, nResults)
+    ccall((:Index_Contains_id, libspatialindex_c), RTError, (IndexH, Ptr{Cdouble}, Ptr{Cdouble}, UInt32, Ptr{Ptr{Int64}}, Ptr{UInt64}), index, pdMin, pdMax, nDimension, ids, nResults)
+end
+
+function Index_TPIntersects_count(index, pdMin, pdMax, pdVMin, pdVMax, tStart, tEnd, nDimension, nResults)
     ccall((:Index_TPIntersects_count, libspatialindex_c), RTError, (IndexH, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Cdouble, Cdouble, UInt32, Ptr{UInt64}), index, pdMin, pdMax, pdVMin, pdVMax, tStart, tEnd, nDimension, nResults)
 end
 
-function Index_MVRIntersects_count(index::IndexH, pdMin, pdMax, tStart::Cdouble, tEnd::Cdouble, nDimension::Integer, nResults)
+function Index_MVRIntersects_count(index, pdMin, pdMax, tStart, tEnd, nDimension, nResults)
     ccall((:Index_MVRIntersects_count, libspatialindex_c), RTError, (IndexH, Ptr{Cdouble}, Ptr{Cdouble}, Cdouble, Cdouble, UInt32, Ptr{UInt64}), index, pdMin, pdMax, tStart, tEnd, nDimension, nResults)
 end
 
-function Index_Intersects_count(index::IndexH, pdMin, pdMax, nDimension::Integer, nResults)
+function Index_Intersects_count(index, pdMin, pdMax, nDimension, nResults)
     ccall((:Index_Intersects_count, libspatialindex_c), RTError, (IndexH, Ptr{Cdouble}, Ptr{Cdouble}, UInt32, Ptr{UInt64}), index, pdMin, pdMax, nDimension, nResults)
 end
 
-function Index_TPNearestNeighbors_obj(index::IndexH, pdMin, pdMax, pdVMin, pdVMax, tStart::Cdouble, tEnd::Cdouble, nDimension::Integer, items, nResults)
+function Index_Contains_count(index, pdMin, pdMax, nDimension, nResults)
+    ccall((:Index_Contains_count, libspatialindex_c), RTError, (IndexH, Ptr{Cdouble}, Ptr{Cdouble}, UInt32, Ptr{UInt64}), index, pdMin, pdMax, nDimension, nResults)
+end
+
+function Index_TPNearestNeighbors_obj(index, pdMin, pdMax, pdVMin, pdVMax, tStart, tEnd, nDimension, items, nResults)
     ccall((:Index_TPNearestNeighbors_obj, libspatialindex_c), RTError, (IndexH, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Cdouble, Cdouble, UInt32, Ptr{Ptr{IndexItemH}}, Ptr{UInt64}), index, pdMin, pdMax, pdVMin, pdVMax, tStart, tEnd, nDimension, items, nResults)
 end
 
-function Index_MVRNearestNeighbors_obj(index::IndexH, pdMin, pdMax, tStart::Cdouble, tEnd::Cdouble, nDimension::Integer, items, nResults)
+function Index_MVRNearestNeighbors_obj(index, pdMin, pdMax, tStart, tEnd, nDimension, items, nResults)
     ccall((:Index_MVRNearestNeighbors_obj, libspatialindex_c), RTError, (IndexH, Ptr{Cdouble}, Ptr{Cdouble}, Cdouble, Cdouble, UInt32, Ptr{Ptr{IndexItemH}}, Ptr{UInt64}), index, pdMin, pdMax, tStart, tEnd, nDimension, items, nResults)
 end
 
-function Index_NearestNeighbors_obj(index::IndexH, pdMin, pdMax, nDimension::Integer, items, nResults)
+function Index_NearestNeighbors_obj(index, pdMin, pdMax, nDimension, items, nResults)
     ccall((:Index_NearestNeighbors_obj, libspatialindex_c), RTError, (IndexH, Ptr{Cdouble}, Ptr{Cdouble}, UInt32, Ptr{Ptr{IndexItemH}}, Ptr{UInt64}), index, pdMin, pdMax, nDimension, items, nResults)
 end
 
-function Index_TPNearestNeighbors_id(index::IndexH, pdMin, pdMax, pdVMin, pdVMax, tStart::Cdouble, tEnd::Cdouble, nDimension::Integer, ids, nResults)
+function Index_TPNearestNeighbors_id(index, pdMin, pdMax, pdVMin, pdVMax, tStart, tEnd, nDimension, ids, nResults)
     ccall((:Index_TPNearestNeighbors_id, libspatialindex_c), RTError, (IndexH, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Cdouble, Cdouble, UInt32, Ptr{Ptr{Int64}}, Ptr{UInt64}), index, pdMin, pdMax, pdVMin, pdVMax, tStart, tEnd, nDimension, ids, nResults)
 end
 
-function Index_MVRNearestNeighbors_id(index::IndexH, pdMin, pdMax, tStart::Cdouble, tEnd::Cdouble, nDimension::Integer, ids, nResults)
+function Index_MVRNearestNeighbors_id(index, pdMin, pdMax, tStart, tEnd, nDimension, ids, nResults)
     ccall((:Index_MVRNearestNeighbors_id, libspatialindex_c), RTError, (IndexH, Ptr{Cdouble}, Ptr{Cdouble}, Cdouble, Cdouble, UInt32, Ptr{Ptr{Int64}}, Ptr{UInt64}), index, pdMin, pdMax, tStart, tEnd, nDimension, ids, nResults)
 end
 
-function Index_NearestNeighbors_id(index::IndexH, pdMin, pdMax, nDimension::Integer, items, nResults)
+function Index_NearestNeighbors_id(index, pdMin, pdMax, nDimension, items, nResults)
     ccall((:Index_NearestNeighbors_id, libspatialindex_c), RTError, (IndexH, Ptr{Cdouble}, Ptr{Cdouble}, UInt32, Ptr{Ptr{Int64}}, Ptr{UInt64}), index, pdMin, pdMax, nDimension, items, nResults)
 end
 
-function Index_GetBounds(index::IndexH, ppdMin, ppdMax, nDimension)
+function Index_Intersects_internal(index, pdMin, pdMax, nDimension, items, nResults)
+    ccall((:Index_Intersects_internal, libspatialindex_c), RTError, (IndexH, Ptr{Cdouble}, Ptr{Cdouble}, UInt32, Ptr{Ptr{IndexItemH}}, Ptr{UInt64}), index, pdMin, pdMax, nDimension, items, nResults)
+end
+
+function Index_GetBounds(index, ppdMin, ppdMax, nDimension)
     ccall((:Index_GetBounds, libspatialindex_c), RTError, (IndexH, Ptr{Ptr{Cdouble}}, Ptr{Ptr{Cdouble}}, Ptr{UInt32}), index, ppdMin, ppdMax, nDimension)
 end
 
-function Index_GetLeaves(index::IndexH, nLeafNodes, nLeafSizes, nLeafIDs, nLeafChildIDs, pppdMin, pppdMax, nDimension)
+function Index_GetLeaves(index, nLeafNodes, nLeafSizes, nLeafIDs, nLeafChildIDs, pppdMin, pppdMax, nDimension)
     ccall((:Index_GetLeaves, libspatialindex_c), RTError, (IndexH, Ptr{UInt32}, Ptr{Ptr{UInt32}}, Ptr{Ptr{Int64}}, Ptr{Ptr{Ptr{Int64}}}, Ptr{Ptr{Ptr{Cdouble}}}, Ptr{Ptr{Ptr{Cdouble}}}, Ptr{UInt32}), index, nLeafNodes, nLeafSizes, nLeafIDs, nLeafChildIDs, pppdMin, pppdMax, nDimension)
 end
 
-function Index_SetResultSetOffset(index::IndexH, value::Integer)
+function Index_SetResultSetOffset(index, value)
     ccall((:Index_SetResultSetOffset, libspatialindex_c), RTError, (IndexH, Int64), index, value)
 end
 
-function Index_GetResultSetOffset(index::IndexH)
+function Index_GetResultSetOffset(index)
     ccall((:Index_GetResultSetOffset, libspatialindex_c), Int64, (IndexH,), index)
 end
 
-function Index_SetResultSetLimit(index::IndexH, value::Integer)
+function Index_SetResultSetLimit(index, value)
     ccall((:Index_SetResultSetLimit, libspatialindex_c), RTError, (IndexH, Int64), index, value)
 end
 
-function Index_GetResultSetLimit(index::IndexH)
+function Index_GetResultSetLimit(index)
     ccall((:Index_GetResultSetLimit, libspatialindex_c), Int64, (IndexH,), index)
 end
 
-function Index_DestroyObjResults(results, nResults::Integer)
-    ccall((:Index_DestroyObjResults, libspatialindex_c), Nothing, (Ptr{IndexItemH}, UInt32), results, nResults)
+function Index_DestroyObjResults(results, nResults)
+    ccall((:Index_DestroyObjResults, libspatialindex_c), Cvoid, (Ptr{IndexItemH}, UInt32), results, nResults)
 end
 
-function Index_ClearBuffer(index::IndexH)
-    ccall((:Index_ClearBuffer, libspatialindex_c), Nothing, (IndexH,), index)
+function Index_ClearBuffer(index)
+    ccall((:Index_ClearBuffer, libspatialindex_c), Cvoid, (IndexH,), index)
 end
 
 function Index_Free(object)
-    ccall((:Index_Free, libspatialindex_c), Nothing, (Ptr{Nothing},), object)
+    ccall((:Index_Free, libspatialindex_c), Cvoid, (Ptr{Cvoid},), object)
 end
 
-function Index_Flush(index::IndexH)
-    ccall((:Index_Flush, libspatialindex_c), Nothing, (IndexH,), index)
+function Index_Flush(index)
+    ccall((:Index_Flush, libspatialindex_c), Cvoid, (IndexH,), index)
 end
 
-function IndexItem_Destroy(item::IndexItemH)
-    ccall((:IndexItem_Destroy, libspatialindex_c), Nothing, (IndexItemH,), item)
+function IndexItem_Destroy(item)
+    ccall((:IndexItem_Destroy, libspatialindex_c), Cvoid, (IndexItemH,), item)
 end
 
-function IndexItem_GetID(item::IndexItemH)
+function IndexItem_GetID(item)
     ccall((:IndexItem_GetID, libspatialindex_c), Int64, (IndexItemH,), item)
 end
 
-function IndexItem_GetData(item::IndexItemH, data, length)
+function IndexItem_GetData(item, data, length)
     ccall((:IndexItem_GetData, libspatialindex_c), RTError, (IndexItemH, Ptr{Ptr{UInt8}}, Ptr{UInt64}), item, data, length)
 end
 
-function IndexItem_GetBounds(item::IndexItemH, ppdMin, ppdMax, nDimension)
+function IndexItem_GetBounds(item, ppdMin, ppdMax, nDimension)
     ccall((:IndexItem_GetBounds, libspatialindex_c), RTError, (IndexItemH, Ptr{Ptr{Cdouble}}, Ptr{Ptr{Cdouble}}, Ptr{UInt32}), item, ppdMin, ppdMax, nDimension)
 end
 
@@ -166,231 +178,231 @@ function IndexProperty_Create()
     ccall((:IndexProperty_Create, libspatialindex_c), IndexPropertyH, ())
 end
 
-function IndexProperty_Destroy(hProp::IndexPropertyH)
-    ccall((:IndexProperty_Destroy, libspatialindex_c), Nothing, (IndexPropertyH,), hProp)
+function IndexProperty_Destroy(hProp)
+    ccall((:IndexProperty_Destroy, libspatialindex_c), Cvoid, (IndexPropertyH,), hProp)
 end
 
-function IndexProperty_SetIndexType(iprop::IndexPropertyH, value::RTIndexType)
+function IndexProperty_SetIndexType(iprop, value)
     ccall((:IndexProperty_SetIndexType, libspatialindex_c), RTError, (IndexPropertyH, RTIndexType), iprop, value)
 end
 
-function IndexProperty_GetIndexType(iprop::IndexPropertyH)
+function IndexProperty_GetIndexType(iprop)
     ccall((:IndexProperty_GetIndexType, libspatialindex_c), RTIndexType, (IndexPropertyH,), iprop)
 end
 
-function IndexProperty_SetDimension(iprop::IndexPropertyH, value::Integer)
+function IndexProperty_SetDimension(iprop, value)
     ccall((:IndexProperty_SetDimension, libspatialindex_c), RTError, (IndexPropertyH, UInt32), iprop, value)
 end
 
-function IndexProperty_GetDimension(iprop::IndexPropertyH)
+function IndexProperty_GetDimension(iprop)
     ccall((:IndexProperty_GetDimension, libspatialindex_c), UInt32, (IndexPropertyH,), iprop)
 end
 
-function IndexProperty_SetIndexVariant(iprop::IndexPropertyH, value::RTIndexVariant)
+function IndexProperty_SetIndexVariant(iprop, value)
     ccall((:IndexProperty_SetIndexVariant, libspatialindex_c), RTError, (IndexPropertyH, RTIndexVariant), iprop, value)
 end
 
-function IndexProperty_GetIndexVariant(iprop::IndexPropertyH)
+function IndexProperty_GetIndexVariant(iprop)
     ccall((:IndexProperty_GetIndexVariant, libspatialindex_c), RTIndexVariant, (IndexPropertyH,), iprop)
 end
 
-function IndexProperty_SetIndexStorage(iprop::IndexPropertyH, value::RTStorageType)
+function IndexProperty_SetIndexStorage(iprop, value)
     ccall((:IndexProperty_SetIndexStorage, libspatialindex_c), RTError, (IndexPropertyH, RTStorageType), iprop, value)
 end
 
-function IndexProperty_GetIndexStorage(iprop::IndexPropertyH)
+function IndexProperty_GetIndexStorage(iprop)
     ccall((:IndexProperty_GetIndexStorage, libspatialindex_c), RTStorageType, (IndexPropertyH,), iprop)
 end
 
-function IndexProperty_SetPagesize(iprop::IndexPropertyH, value::Integer)
+function IndexProperty_SetPagesize(iprop, value)
     ccall((:IndexProperty_SetPagesize, libspatialindex_c), RTError, (IndexPropertyH, UInt32), iprop, value)
 end
 
-function IndexProperty_GetPagesize(iprop::IndexPropertyH)
+function IndexProperty_GetPagesize(iprop)
     ccall((:IndexProperty_GetPagesize, libspatialindex_c), UInt32, (IndexPropertyH,), iprop)
 end
 
-function IndexProperty_SetIndexCapacity(iprop::IndexPropertyH, value::Integer)
+function IndexProperty_SetIndexCapacity(iprop, value)
     ccall((:IndexProperty_SetIndexCapacity, libspatialindex_c), RTError, (IndexPropertyH, UInt32), iprop, value)
 end
 
-function IndexProperty_GetIndexCapacity(iprop::IndexPropertyH)
+function IndexProperty_GetIndexCapacity(iprop)
     ccall((:IndexProperty_GetIndexCapacity, libspatialindex_c), UInt32, (IndexPropertyH,), iprop)
 end
 
-function IndexProperty_SetLeafCapacity(iprop::IndexPropertyH, value::Integer)
+function IndexProperty_SetLeafCapacity(iprop, value)
     ccall((:IndexProperty_SetLeafCapacity, libspatialindex_c), RTError, (IndexPropertyH, UInt32), iprop, value)
 end
 
-function IndexProperty_GetLeafCapacity(iprop::IndexPropertyH)
+function IndexProperty_GetLeafCapacity(iprop)
     ccall((:IndexProperty_GetLeafCapacity, libspatialindex_c), UInt32, (IndexPropertyH,), iprop)
 end
 
-function IndexProperty_SetLeafPoolCapacity(iprop::IndexPropertyH, value::Integer)
+function IndexProperty_SetLeafPoolCapacity(iprop, value)
     ccall((:IndexProperty_SetLeafPoolCapacity, libspatialindex_c), RTError, (IndexPropertyH, UInt32), iprop, value)
 end
 
-function IndexProperty_GetLeafPoolCapacity(iprop::IndexPropertyH)
+function IndexProperty_GetLeafPoolCapacity(iprop)
     ccall((:IndexProperty_GetLeafPoolCapacity, libspatialindex_c), UInt32, (IndexPropertyH,), iprop)
 end
 
-function IndexProperty_SetIndexPoolCapacity(iprop::IndexPropertyH, value::Integer)
+function IndexProperty_SetIndexPoolCapacity(iprop, value)
     ccall((:IndexProperty_SetIndexPoolCapacity, libspatialindex_c), RTError, (IndexPropertyH, UInt32), iprop, value)
 end
 
-function IndexProperty_GetIndexPoolCapacity(iprop::IndexPropertyH)
+function IndexProperty_GetIndexPoolCapacity(iprop)
     ccall((:IndexProperty_GetIndexPoolCapacity, libspatialindex_c), UInt32, (IndexPropertyH,), iprop)
 end
 
-function IndexProperty_SetRegionPoolCapacity(iprop::IndexPropertyH, value::Integer)
+function IndexProperty_SetRegionPoolCapacity(iprop, value)
     ccall((:IndexProperty_SetRegionPoolCapacity, libspatialindex_c), RTError, (IndexPropertyH, UInt32), iprop, value)
 end
 
-function IndexProperty_GetRegionPoolCapacity(iprop::IndexPropertyH)
+function IndexProperty_GetRegionPoolCapacity(iprop)
     ccall((:IndexProperty_GetRegionPoolCapacity, libspatialindex_c), UInt32, (IndexPropertyH,), iprop)
 end
 
-function IndexProperty_SetPointPoolCapacity(iprop::IndexPropertyH, value::Integer)
+function IndexProperty_SetPointPoolCapacity(iprop, value)
     ccall((:IndexProperty_SetPointPoolCapacity, libspatialindex_c), RTError, (IndexPropertyH, UInt32), iprop, value)
 end
 
-function IndexProperty_GetPointPoolCapacity(iprop::IndexPropertyH)
+function IndexProperty_GetPointPoolCapacity(iprop)
     ccall((:IndexProperty_GetPointPoolCapacity, libspatialindex_c), UInt32, (IndexPropertyH,), iprop)
 end
 
-function IndexProperty_SetBufferingCapacity(iprop::IndexPropertyH, value::Integer)
+function IndexProperty_SetBufferingCapacity(iprop, value)
     ccall((:IndexProperty_SetBufferingCapacity, libspatialindex_c), RTError, (IndexPropertyH, UInt32), iprop, value)
 end
 
-function IndexProperty_GetBufferingCapacity(iprop::IndexPropertyH)
+function IndexProperty_GetBufferingCapacity(iprop)
     ccall((:IndexProperty_GetBufferingCapacity, libspatialindex_c), UInt32, (IndexPropertyH,), iprop)
 end
 
-function IndexProperty_SetEnsureTightMBRs(iprop::IndexPropertyH, value::Integer)
+function IndexProperty_SetEnsureTightMBRs(iprop, value)
     ccall((:IndexProperty_SetEnsureTightMBRs, libspatialindex_c), RTError, (IndexPropertyH, UInt32), iprop, value)
 end
 
-function IndexProperty_GetEnsureTightMBRs(iprop::IndexPropertyH)
+function IndexProperty_GetEnsureTightMBRs(iprop)
     ccall((:IndexProperty_GetEnsureTightMBRs, libspatialindex_c), UInt32, (IndexPropertyH,), iprop)
 end
 
-function IndexProperty_SetOverwrite(iprop::IndexPropertyH, value::Integer)
+function IndexProperty_SetOverwrite(iprop, value)
     ccall((:IndexProperty_SetOverwrite, libspatialindex_c), RTError, (IndexPropertyH, UInt32), iprop, value)
 end
 
-function IndexProperty_GetOverwrite(iprop::IndexPropertyH)
+function IndexProperty_GetOverwrite(iprop)
     ccall((:IndexProperty_GetOverwrite, libspatialindex_c), UInt32, (IndexPropertyH,), iprop)
 end
 
-function IndexProperty_SetNearMinimumOverlapFactor(iprop::IndexPropertyH, value::Integer)
+function IndexProperty_SetNearMinimumOverlapFactor(iprop, value)
     ccall((:IndexProperty_SetNearMinimumOverlapFactor, libspatialindex_c), RTError, (IndexPropertyH, UInt32), iprop, value)
 end
 
-function IndexProperty_GetNearMinimumOverlapFactor(iprop::IndexPropertyH)
+function IndexProperty_GetNearMinimumOverlapFactor(iprop)
     ccall((:IndexProperty_GetNearMinimumOverlapFactor, libspatialindex_c), UInt32, (IndexPropertyH,), iprop)
 end
 
-function IndexProperty_SetWriteThrough(iprop::IndexPropertyH, value::Integer)
+function IndexProperty_SetWriteThrough(iprop, value)
     ccall((:IndexProperty_SetWriteThrough, libspatialindex_c), RTError, (IndexPropertyH, UInt32), iprop, value)
 end
 
-function IndexProperty_GetWriteThrough(iprop::IndexPropertyH)
+function IndexProperty_GetWriteThrough(iprop)
     ccall((:IndexProperty_GetWriteThrough, libspatialindex_c), UInt32, (IndexPropertyH,), iprop)
 end
 
-function IndexProperty_SetFillFactor(iprop::IndexPropertyH, value::Cdouble)
+function IndexProperty_SetFillFactor(iprop, value)
     ccall((:IndexProperty_SetFillFactor, libspatialindex_c), RTError, (IndexPropertyH, Cdouble), iprop, value)
 end
 
-function IndexProperty_GetFillFactor(iprop::IndexPropertyH)
+function IndexProperty_GetFillFactor(iprop)
     ccall((:IndexProperty_GetFillFactor, libspatialindex_c), Cdouble, (IndexPropertyH,), iprop)
 end
 
-function IndexProperty_SetSplitDistributionFactor(iprop::IndexPropertyH, value::Cdouble)
+function IndexProperty_SetSplitDistributionFactor(iprop, value)
     ccall((:IndexProperty_SetSplitDistributionFactor, libspatialindex_c), RTError, (IndexPropertyH, Cdouble), iprop, value)
 end
 
-function IndexProperty_GetSplitDistributionFactor(iprop::IndexPropertyH)
+function IndexProperty_GetSplitDistributionFactor(iprop)
     ccall((:IndexProperty_GetSplitDistributionFactor, libspatialindex_c), Cdouble, (IndexPropertyH,), iprop)
 end
 
-function IndexProperty_SetTPRHorizon(iprop::IndexPropertyH, value::Cdouble)
+function IndexProperty_SetTPRHorizon(iprop, value)
     ccall((:IndexProperty_SetTPRHorizon, libspatialindex_c), RTError, (IndexPropertyH, Cdouble), iprop, value)
 end
 
-function IndexProperty_GetTPRHorizon(iprop::IndexPropertyH)
+function IndexProperty_GetTPRHorizon(iprop)
     ccall((:IndexProperty_GetTPRHorizon, libspatialindex_c), Cdouble, (IndexPropertyH,), iprop)
 end
 
-function IndexProperty_SetReinsertFactor(iprop::IndexPropertyH, value::Cdouble)
+function IndexProperty_SetReinsertFactor(iprop, value)
     ccall((:IndexProperty_SetReinsertFactor, libspatialindex_c), RTError, (IndexPropertyH, Cdouble), iprop, value)
 end
 
-function IndexProperty_GetReinsertFactor(iprop::IndexPropertyH)
+function IndexProperty_GetReinsertFactor(iprop)
     ccall((:IndexProperty_GetReinsertFactor, libspatialindex_c), Cdouble, (IndexPropertyH,), iprop)
 end
 
-function IndexProperty_SetFileName(iprop::IndexPropertyH, value)
+function IndexProperty_SetFileName(iprop, value)
     ccall((:IndexProperty_SetFileName, libspatialindex_c), RTError, (IndexPropertyH, Cstring), iprop, value)
 end
 
-function IndexProperty_GetFileName(iprop::IndexPropertyH)
+function IndexProperty_GetFileName(iprop)
     ccall((:IndexProperty_GetFileName, libspatialindex_c), Cstring, (IndexPropertyH,), iprop)
 end
 
-function IndexProperty_SetFileNameExtensionDat(iprop::IndexPropertyH, value)
+function IndexProperty_SetFileNameExtensionDat(iprop, value)
     ccall((:IndexProperty_SetFileNameExtensionDat, libspatialindex_c), RTError, (IndexPropertyH, Cstring), iprop, value)
 end
 
-function IndexProperty_GetFileNameExtensionDat(iprop::IndexPropertyH)
+function IndexProperty_GetFileNameExtensionDat(iprop)
     ccall((:IndexProperty_GetFileNameExtensionDat, libspatialindex_c), Cstring, (IndexPropertyH,), iprop)
 end
 
-function IndexProperty_SetFileNameExtensionIdx(iprop::IndexPropertyH, value)
+function IndexProperty_SetFileNameExtensionIdx(iprop, value)
     ccall((:IndexProperty_SetFileNameExtensionIdx, libspatialindex_c), RTError, (IndexPropertyH, Cstring), iprop, value)
 end
 
-function IndexProperty_GetFileNameExtensionIdx(iprop::IndexPropertyH)
+function IndexProperty_GetFileNameExtensionIdx(iprop)
     ccall((:IndexProperty_GetFileNameExtensionIdx, libspatialindex_c), Cstring, (IndexPropertyH,), iprop)
 end
 
-function IndexProperty_SetCustomStorageCallbacksSize(iprop::IndexPropertyH, value::Integer)
+function IndexProperty_SetCustomStorageCallbacksSize(iprop, value)
     ccall((:IndexProperty_SetCustomStorageCallbacksSize, libspatialindex_c), RTError, (IndexPropertyH, UInt32), iprop, value)
 end
 
-function IndexProperty_GetCustomStorageCallbacksSize(iprop::IndexPropertyH)
+function IndexProperty_GetCustomStorageCallbacksSize(iprop)
     ccall((:IndexProperty_GetCustomStorageCallbacksSize, libspatialindex_c), UInt32, (IndexPropertyH,), iprop)
 end
 
-function IndexProperty_SetCustomStorageCallbacks(iprop::IndexPropertyH, value)
-    ccall((:IndexProperty_SetCustomStorageCallbacks, libspatialindex_c), RTError, (IndexPropertyH, Ptr{Nothing}), iprop, value)
+function IndexProperty_SetCustomStorageCallbacks(iprop, value)
+    ccall((:IndexProperty_SetCustomStorageCallbacks, libspatialindex_c), RTError, (IndexPropertyH, Ptr{Cvoid}), iprop, value)
 end
 
-function IndexProperty_GetCustomStorageCallbacks(iprop::IndexPropertyH)
-    ccall((:IndexProperty_GetCustomStorageCallbacks, libspatialindex_c), Ptr{Nothing}, (IndexPropertyH,), iprop)
+function IndexProperty_GetCustomStorageCallbacks(iprop)
+    ccall((:IndexProperty_GetCustomStorageCallbacks, libspatialindex_c), Ptr{Cvoid}, (IndexPropertyH,), iprop)
 end
 
-function IndexProperty_SetIndexID(iprop::IndexPropertyH, value::Integer)
+function IndexProperty_SetIndexID(iprop, value)
     ccall((:IndexProperty_SetIndexID, libspatialindex_c), RTError, (IndexPropertyH, Int64), iprop, value)
 end
 
-function IndexProperty_GetIndexID(iprop::IndexPropertyH)
+function IndexProperty_GetIndexID(iprop)
     ccall((:IndexProperty_GetIndexID, libspatialindex_c), Int64, (IndexPropertyH,), iprop)
 end
 
-function SIDX_NewBuffer(bytes::Integer)
-    ccall((:SIDX_NewBuffer, libspatialindex_c), Ptr{Nothing}, (Cint,), bytes)
+function SIDX_NewBuffer(bytes)
+    ccall((:SIDX_NewBuffer, libspatialindex_c), Ptr{Cvoid}, (Cint,), bytes)
 end
 
 function SIDX_DeleteBuffer(buffer)
-    ccall((:SIDX_DeleteBuffer, libspatialindex_c), Nothing, (Ptr{Nothing},), buffer)
+    ccall((:SIDX_DeleteBuffer, libspatialindex_c), Cvoid, (Ptr{Cvoid},), buffer)
 end
 
-function IndexProperty_SetResultSetLimit(iprop::IndexPropertyH, value::UInt64)
+function IndexProperty_SetResultSetLimit(iprop, value)
     ccall((:IndexProperty_SetResultSetLimit, libspatialindex_c), RTError, (IndexPropertyH, UInt64), iprop, value)
 end
 
-function IndexProperty_GetResultSetLimit(iprop::IndexPropertyH)
+function IndexProperty_GetResultSetLimit(iprop)
     ccall((:IndexProperty_GetResultSetLimit, libspatialindex_c), UInt64, (IndexPropertyH,), iprop)
 end
 
@@ -401,3 +413,4 @@ end
 function Error_GetLastErrorMsg()
     ccall((:Error_GetLastErrorMsg, libspatialindex_c), Cstring, ())
 end
+

--- a/src/include/sidx_api.jl
+++ b/src/include/sidx_api.jl
@@ -1,416 +1,416 @@
 function Index_Create(properties)
-    ccall((:Index_Create, libspatialindex_c), IndexH, (IndexPropertyH,), properties)
+    @ccall libspatialindex_c.Index_Create(properties::IndexPropertyH)::IndexH
 end
 
 function Index_CreateWithStream(properties, readNext)
-    ccall((:Index_CreateWithStream, libspatialindex_c), IndexH, (IndexPropertyH, Ptr{Cvoid}), properties, readNext)
+    @ccall libspatialindex_c.Index_CreateWithStream(properties::IndexPropertyH, readNext::Ptr{Cvoid})::IndexH
 end
 
 function Index_Destroy(index)
-    ccall((:Index_Destroy, libspatialindex_c), Cvoid, (IndexH,), index)
+    @ccall libspatialindex_c.Index_Destroy(index::IndexH)::Cvoid
 end
 
 function Index_GetProperties(index)
-    ccall((:Index_GetProperties, libspatialindex_c), IndexPropertyH, (IndexH,), index)
+    @ccall libspatialindex_c.Index_GetProperties(index::IndexH)::IndexPropertyH
 end
 
 function Index_DeleteData(index, id, pdMin, pdMax, nDimension)
-    ccall((:Index_DeleteData, libspatialindex_c), RTError, (IndexH, Int64, Ptr{Cdouble}, Ptr{Cdouble}, UInt32), index, id, pdMin, pdMax, nDimension)
+    @ccall libspatialindex_c.Index_DeleteData(index::IndexH, id::Int64, pdMin::Ptr{Cdouble}, pdMax::Ptr{Cdouble}, nDimension::UInt32)::RTError
 end
 
 function Index_DeleteTPData(index, id, pdMin, pdMax, pdVMin, pdVMax, tStart, tEnd, nDimension)
-    ccall((:Index_DeleteTPData, libspatialindex_c), RTError, (IndexH, Int64, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Cdouble, Cdouble, UInt32), index, id, pdMin, pdMax, pdVMin, pdVMax, tStart, tEnd, nDimension)
+    @ccall libspatialindex_c.Index_DeleteTPData(index::IndexH, id::Int64, pdMin::Ptr{Cdouble}, pdMax::Ptr{Cdouble}, pdVMin::Ptr{Cdouble}, pdVMax::Ptr{Cdouble}, tStart::Cdouble, tEnd::Cdouble, nDimension::UInt32)::RTError
 end
 
 function Index_DeleteMVRData(index, id, pdMin, pdMax, tStart, tEnd, nDimension)
-    ccall((:Index_DeleteMVRData, libspatialindex_c), RTError, (IndexH, Int64, Ptr{Cdouble}, Ptr{Cdouble}, Cdouble, Cdouble, UInt32), index, id, pdMin, pdMax, tStart, tEnd, nDimension)
+    @ccall libspatialindex_c.Index_DeleteMVRData(index::IndexH, id::Int64, pdMin::Ptr{Cdouble}, pdMax::Ptr{Cdouble}, tStart::Cdouble, tEnd::Cdouble, nDimension::UInt32)::RTError
 end
 
 function Index_InsertData(index, id, pdMin, pdMax, nDimension, pData, nDataLength)
-    ccall((:Index_InsertData, libspatialindex_c), RTError, (IndexH, Int64, Ptr{Cdouble}, Ptr{Cdouble}, UInt32, Ptr{UInt8}, Cint), index, id, pdMin, pdMax, nDimension, pData, nDataLength)
+    @ccall libspatialindex_c.Index_InsertData(index::IndexH, id::Int64, pdMin::Ptr{Cdouble}, pdMax::Ptr{Cdouble}, nDimension::UInt32, pData::Ptr{UInt8}, nDataLength::Cint)::RTError
 end
 
 function Index_InsertTPData(index, id, pdMin, pdMax, pdVMin, pdVMax, tStart, tEnd, nDimension, pData, nDataLength)
-    ccall((:Index_InsertTPData, libspatialindex_c), RTError, (IndexH, Int64, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Cdouble, Cdouble, UInt32, Ptr{UInt8}, Cint), index, id, pdMin, pdMax, pdVMin, pdVMax, tStart, tEnd, nDimension, pData, nDataLength)
+    @ccall libspatialindex_c.Index_InsertTPData(index::IndexH, id::Int64, pdMin::Ptr{Cdouble}, pdMax::Ptr{Cdouble}, pdVMin::Ptr{Cdouble}, pdVMax::Ptr{Cdouble}, tStart::Cdouble, tEnd::Cdouble, nDimension::UInt32, pData::Ptr{UInt8}, nDataLength::Cint)::RTError
 end
 
 function Index_InsertMVRData(index, id, pdMin, pdMax, tStart, tEnd, nDimension, pData, nDataLength)
-    ccall((:Index_InsertMVRData, libspatialindex_c), RTError, (IndexH, Int64, Ptr{Cdouble}, Ptr{Cdouble}, Cdouble, Cdouble, UInt32, Ptr{UInt8}, Cint), index, id, pdMin, pdMax, tStart, tEnd, nDimension, pData, nDataLength)
+    @ccall libspatialindex_c.Index_InsertMVRData(index::IndexH, id::Int64, pdMin::Ptr{Cdouble}, pdMax::Ptr{Cdouble}, tStart::Cdouble, tEnd::Cdouble, nDimension::UInt32, pData::Ptr{UInt8}, nDataLength::Cint)::RTError
 end
 
 function Index_IsValid(index)
-    ccall((:Index_IsValid, libspatialindex_c), UInt32, (IndexH,), index)
+    @ccall libspatialindex_c.Index_IsValid(index::IndexH)::UInt32
 end
 
 function Index_TPIntersects_obj(index, pdMin, pdMax, pdVMin, pdVMax, tStart, tEnd, nDimension, items, nResults)
-    ccall((:Index_TPIntersects_obj, libspatialindex_c), RTError, (IndexH, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Cdouble, Cdouble, UInt32, Ptr{Ptr{IndexItemH}}, Ptr{UInt64}), index, pdMin, pdMax, pdVMin, pdVMax, tStart, tEnd, nDimension, items, nResults)
+    @ccall libspatialindex_c.Index_TPIntersects_obj(index::IndexH, pdMin::Ptr{Cdouble}, pdMax::Ptr{Cdouble}, pdVMin::Ptr{Cdouble}, pdVMax::Ptr{Cdouble}, tStart::Cdouble, tEnd::Cdouble, nDimension::UInt32, items::Ptr{Ptr{IndexItemH}}, nResults::Ptr{UInt64})::RTError
 end
 
 function Index_MVRIntersects_obj(index, pdMin, pdMax, tStart, tEnd, nDimension, items, nResults)
-    ccall((:Index_MVRIntersects_obj, libspatialindex_c), RTError, (IndexH, Ptr{Cdouble}, Ptr{Cdouble}, Cdouble, Cdouble, UInt32, Ptr{Ptr{IndexItemH}}, Ptr{UInt64}), index, pdMin, pdMax, tStart, tEnd, nDimension, items, nResults)
+    @ccall libspatialindex_c.Index_MVRIntersects_obj(index::IndexH, pdMin::Ptr{Cdouble}, pdMax::Ptr{Cdouble}, tStart::Cdouble, tEnd::Cdouble, nDimension::UInt32, items::Ptr{Ptr{IndexItemH}}, nResults::Ptr{UInt64})::RTError
 end
 
 function Index_Intersects_obj(index, pdMin, pdMax, nDimension, items, nResults)
-    ccall((:Index_Intersects_obj, libspatialindex_c), RTError, (IndexH, Ptr{Cdouble}, Ptr{Cdouble}, UInt32, Ptr{Ptr{IndexItemH}}, Ptr{UInt64}), index, pdMin, pdMax, nDimension, items, nResults)
+    @ccall libspatialindex_c.Index_Intersects_obj(index::IndexH, pdMin::Ptr{Cdouble}, pdMax::Ptr{Cdouble}, nDimension::UInt32, items::Ptr{Ptr{IndexItemH}}, nResults::Ptr{UInt64})::RTError
 end
 
 function Index_Contains_obj(index, pdMin, pdMax, nDimension, items, nResults)
-    ccall((:Index_Contains_obj, libspatialindex_c), RTError, (IndexH, Ptr{Cdouble}, Ptr{Cdouble}, UInt32, Ptr{Ptr{IndexItemH}}, Ptr{UInt64}), index, pdMin, pdMax, nDimension, items, nResults)
+    @ccall libspatialindex_c.Index_Contains_obj(index::IndexH, pdMin::Ptr{Cdouble}, pdMax::Ptr{Cdouble}, nDimension::UInt32, items::Ptr{Ptr{IndexItemH}}, nResults::Ptr{UInt64})::RTError
 end
 
 function Index_TPIntersects_id(index, pdMin, pdMax, pdVMin, pdVMax, tStart, tEnd, nDimension, ids, nResults)
-    ccall((:Index_TPIntersects_id, libspatialindex_c), RTError, (IndexH, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Cdouble, Cdouble, UInt32, Ptr{Ptr{Int64}}, Ptr{UInt64}), index, pdMin, pdMax, pdVMin, pdVMax, tStart, tEnd, nDimension, ids, nResults)
+    @ccall libspatialindex_c.Index_TPIntersects_id(index::IndexH, pdMin::Ptr{Cdouble}, pdMax::Ptr{Cdouble}, pdVMin::Ptr{Cdouble}, pdVMax::Ptr{Cdouble}, tStart::Cdouble, tEnd::Cdouble, nDimension::UInt32, ids::Ptr{Ptr{Int64}}, nResults::Ptr{UInt64})::RTError
 end
 
 function Index_MVRIntersects_id(index, pdMin, pdMax, tStart, tEnd, nDimension, ids, nResults)
-    ccall((:Index_MVRIntersects_id, libspatialindex_c), RTError, (IndexH, Ptr{Cdouble}, Ptr{Cdouble}, Cdouble, Cdouble, UInt32, Ptr{Ptr{Int64}}, Ptr{UInt64}), index, pdMin, pdMax, tStart, tEnd, nDimension, ids, nResults)
+    @ccall libspatialindex_c.Index_MVRIntersects_id(index::IndexH, pdMin::Ptr{Cdouble}, pdMax::Ptr{Cdouble}, tStart::Cdouble, tEnd::Cdouble, nDimension::UInt32, ids::Ptr{Ptr{Int64}}, nResults::Ptr{UInt64})::RTError
 end
 
 function Index_Intersects_id(index, pdMin, pdMax, nDimension, items, nResults)
-    ccall((:Index_Intersects_id, libspatialindex_c), RTError, (IndexH, Ptr{Cdouble}, Ptr{Cdouble}, UInt32, Ptr{Ptr{Int64}}, Ptr{UInt64}), index, pdMin, pdMax, nDimension, items, nResults)
+    @ccall libspatialindex_c.Index_Intersects_id(index::IndexH, pdMin::Ptr{Cdouble}, pdMax::Ptr{Cdouble}, nDimension::UInt32, items::Ptr{Ptr{Int64}}, nResults::Ptr{UInt64})::RTError
 end
 
 function Index_Contains_id(index, pdMin, pdMax, nDimension, ids, nResults)
-    ccall((:Index_Contains_id, libspatialindex_c), RTError, (IndexH, Ptr{Cdouble}, Ptr{Cdouble}, UInt32, Ptr{Ptr{Int64}}, Ptr{UInt64}), index, pdMin, pdMax, nDimension, ids, nResults)
+    @ccall libspatialindex_c.Index_Contains_id(index::IndexH, pdMin::Ptr{Cdouble}, pdMax::Ptr{Cdouble}, nDimension::UInt32, ids::Ptr{Ptr{Int64}}, nResults::Ptr{UInt64})::RTError
 end
 
 function Index_TPIntersects_count(index, pdMin, pdMax, pdVMin, pdVMax, tStart, tEnd, nDimension, nResults)
-    ccall((:Index_TPIntersects_count, libspatialindex_c), RTError, (IndexH, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Cdouble, Cdouble, UInt32, Ptr{UInt64}), index, pdMin, pdMax, pdVMin, pdVMax, tStart, tEnd, nDimension, nResults)
+    @ccall libspatialindex_c.Index_TPIntersects_count(index::IndexH, pdMin::Ptr{Cdouble}, pdMax::Ptr{Cdouble}, pdVMin::Ptr{Cdouble}, pdVMax::Ptr{Cdouble}, tStart::Cdouble, tEnd::Cdouble, nDimension::UInt32, nResults::Ptr{UInt64})::RTError
 end
 
 function Index_MVRIntersects_count(index, pdMin, pdMax, tStart, tEnd, nDimension, nResults)
-    ccall((:Index_MVRIntersects_count, libspatialindex_c), RTError, (IndexH, Ptr{Cdouble}, Ptr{Cdouble}, Cdouble, Cdouble, UInt32, Ptr{UInt64}), index, pdMin, pdMax, tStart, tEnd, nDimension, nResults)
+    @ccall libspatialindex_c.Index_MVRIntersects_count(index::IndexH, pdMin::Ptr{Cdouble}, pdMax::Ptr{Cdouble}, tStart::Cdouble, tEnd::Cdouble, nDimension::UInt32, nResults::Ptr{UInt64})::RTError
 end
 
 function Index_Intersects_count(index, pdMin, pdMax, nDimension, nResults)
-    ccall((:Index_Intersects_count, libspatialindex_c), RTError, (IndexH, Ptr{Cdouble}, Ptr{Cdouble}, UInt32, Ptr{UInt64}), index, pdMin, pdMax, nDimension, nResults)
+    @ccall libspatialindex_c.Index_Intersects_count(index::IndexH, pdMin::Ptr{Cdouble}, pdMax::Ptr{Cdouble}, nDimension::UInt32, nResults::Ptr{UInt64})::RTError
 end
 
 function Index_Contains_count(index, pdMin, pdMax, nDimension, nResults)
-    ccall((:Index_Contains_count, libspatialindex_c), RTError, (IndexH, Ptr{Cdouble}, Ptr{Cdouble}, UInt32, Ptr{UInt64}), index, pdMin, pdMax, nDimension, nResults)
+    @ccall libspatialindex_c.Index_Contains_count(index::IndexH, pdMin::Ptr{Cdouble}, pdMax::Ptr{Cdouble}, nDimension::UInt32, nResults::Ptr{UInt64})::RTError
 end
 
 function Index_TPNearestNeighbors_obj(index, pdMin, pdMax, pdVMin, pdVMax, tStart, tEnd, nDimension, items, nResults)
-    ccall((:Index_TPNearestNeighbors_obj, libspatialindex_c), RTError, (IndexH, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Cdouble, Cdouble, UInt32, Ptr{Ptr{IndexItemH}}, Ptr{UInt64}), index, pdMin, pdMax, pdVMin, pdVMax, tStart, tEnd, nDimension, items, nResults)
+    @ccall libspatialindex_c.Index_TPNearestNeighbors_obj(index::IndexH, pdMin::Ptr{Cdouble}, pdMax::Ptr{Cdouble}, pdVMin::Ptr{Cdouble}, pdVMax::Ptr{Cdouble}, tStart::Cdouble, tEnd::Cdouble, nDimension::UInt32, items::Ptr{Ptr{IndexItemH}}, nResults::Ptr{UInt64})::RTError
 end
 
 function Index_MVRNearestNeighbors_obj(index, pdMin, pdMax, tStart, tEnd, nDimension, items, nResults)
-    ccall((:Index_MVRNearestNeighbors_obj, libspatialindex_c), RTError, (IndexH, Ptr{Cdouble}, Ptr{Cdouble}, Cdouble, Cdouble, UInt32, Ptr{Ptr{IndexItemH}}, Ptr{UInt64}), index, pdMin, pdMax, tStart, tEnd, nDimension, items, nResults)
+    @ccall libspatialindex_c.Index_MVRNearestNeighbors_obj(index::IndexH, pdMin::Ptr{Cdouble}, pdMax::Ptr{Cdouble}, tStart::Cdouble, tEnd::Cdouble, nDimension::UInt32, items::Ptr{Ptr{IndexItemH}}, nResults::Ptr{UInt64})::RTError
 end
 
 function Index_NearestNeighbors_obj(index, pdMin, pdMax, nDimension, items, nResults)
-    ccall((:Index_NearestNeighbors_obj, libspatialindex_c), RTError, (IndexH, Ptr{Cdouble}, Ptr{Cdouble}, UInt32, Ptr{Ptr{IndexItemH}}, Ptr{UInt64}), index, pdMin, pdMax, nDimension, items, nResults)
+    @ccall libspatialindex_c.Index_NearestNeighbors_obj(index::IndexH, pdMin::Ptr{Cdouble}, pdMax::Ptr{Cdouble}, nDimension::UInt32, items::Ptr{Ptr{IndexItemH}}, nResults::Ptr{UInt64})::RTError
 end
 
 function Index_TPNearestNeighbors_id(index, pdMin, pdMax, pdVMin, pdVMax, tStart, tEnd, nDimension, ids, nResults)
-    ccall((:Index_TPNearestNeighbors_id, libspatialindex_c), RTError, (IndexH, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Cdouble, Cdouble, UInt32, Ptr{Ptr{Int64}}, Ptr{UInt64}), index, pdMin, pdMax, pdVMin, pdVMax, tStart, tEnd, nDimension, ids, nResults)
+    @ccall libspatialindex_c.Index_TPNearestNeighbors_id(index::IndexH, pdMin::Ptr{Cdouble}, pdMax::Ptr{Cdouble}, pdVMin::Ptr{Cdouble}, pdVMax::Ptr{Cdouble}, tStart::Cdouble, tEnd::Cdouble, nDimension::UInt32, ids::Ptr{Ptr{Int64}}, nResults::Ptr{UInt64})::RTError
 end
 
 function Index_MVRNearestNeighbors_id(index, pdMin, pdMax, tStart, tEnd, nDimension, ids, nResults)
-    ccall((:Index_MVRNearestNeighbors_id, libspatialindex_c), RTError, (IndexH, Ptr{Cdouble}, Ptr{Cdouble}, Cdouble, Cdouble, UInt32, Ptr{Ptr{Int64}}, Ptr{UInt64}), index, pdMin, pdMax, tStart, tEnd, nDimension, ids, nResults)
+    @ccall libspatialindex_c.Index_MVRNearestNeighbors_id(index::IndexH, pdMin::Ptr{Cdouble}, pdMax::Ptr{Cdouble}, tStart::Cdouble, tEnd::Cdouble, nDimension::UInt32, ids::Ptr{Ptr{Int64}}, nResults::Ptr{UInt64})::RTError
 end
 
 function Index_NearestNeighbors_id(index, pdMin, pdMax, nDimension, items, nResults)
-    ccall((:Index_NearestNeighbors_id, libspatialindex_c), RTError, (IndexH, Ptr{Cdouble}, Ptr{Cdouble}, UInt32, Ptr{Ptr{Int64}}, Ptr{UInt64}), index, pdMin, pdMax, nDimension, items, nResults)
+    @ccall libspatialindex_c.Index_NearestNeighbors_id(index::IndexH, pdMin::Ptr{Cdouble}, pdMax::Ptr{Cdouble}, nDimension::UInt32, items::Ptr{Ptr{Int64}}, nResults::Ptr{UInt64})::RTError
 end
 
 function Index_Intersects_internal(index, pdMin, pdMax, nDimension, items, nResults)
-    ccall((:Index_Intersects_internal, libspatialindex_c), RTError, (IndexH, Ptr{Cdouble}, Ptr{Cdouble}, UInt32, Ptr{Ptr{IndexItemH}}, Ptr{UInt64}), index, pdMin, pdMax, nDimension, items, nResults)
+    @ccall libspatialindex_c.Index_Intersects_internal(index::IndexH, pdMin::Ptr{Cdouble}, pdMax::Ptr{Cdouble}, nDimension::UInt32, items::Ptr{Ptr{IndexItemH}}, nResults::Ptr{UInt64})::RTError
 end
 
 function Index_GetBounds(index, ppdMin, ppdMax, nDimension)
-    ccall((:Index_GetBounds, libspatialindex_c), RTError, (IndexH, Ptr{Ptr{Cdouble}}, Ptr{Ptr{Cdouble}}, Ptr{UInt32}), index, ppdMin, ppdMax, nDimension)
+    @ccall libspatialindex_c.Index_GetBounds(index::IndexH, ppdMin::Ptr{Ptr{Cdouble}}, ppdMax::Ptr{Ptr{Cdouble}}, nDimension::Ptr{UInt32})::RTError
 end
 
 function Index_GetLeaves(index, nLeafNodes, nLeafSizes, nLeafIDs, nLeafChildIDs, pppdMin, pppdMax, nDimension)
-    ccall((:Index_GetLeaves, libspatialindex_c), RTError, (IndexH, Ptr{UInt32}, Ptr{Ptr{UInt32}}, Ptr{Ptr{Int64}}, Ptr{Ptr{Ptr{Int64}}}, Ptr{Ptr{Ptr{Cdouble}}}, Ptr{Ptr{Ptr{Cdouble}}}, Ptr{UInt32}), index, nLeafNodes, nLeafSizes, nLeafIDs, nLeafChildIDs, pppdMin, pppdMax, nDimension)
+    @ccall libspatialindex_c.Index_GetLeaves(index::IndexH, nLeafNodes::Ptr{UInt32}, nLeafSizes::Ptr{Ptr{UInt32}}, nLeafIDs::Ptr{Ptr{Int64}}, nLeafChildIDs::Ptr{Ptr{Ptr{Int64}}}, pppdMin::Ptr{Ptr{Ptr{Cdouble}}}, pppdMax::Ptr{Ptr{Ptr{Cdouble}}}, nDimension::Ptr{UInt32})::RTError
 end
 
 function Index_SetResultSetOffset(index, value)
-    ccall((:Index_SetResultSetOffset, libspatialindex_c), RTError, (IndexH, Int64), index, value)
+    @ccall libspatialindex_c.Index_SetResultSetOffset(index::IndexH, value::Int64)::RTError
 end
 
 function Index_GetResultSetOffset(index)
-    ccall((:Index_GetResultSetOffset, libspatialindex_c), Int64, (IndexH,), index)
+    @ccall libspatialindex_c.Index_GetResultSetOffset(index::IndexH)::Int64
 end
 
 function Index_SetResultSetLimit(index, value)
-    ccall((:Index_SetResultSetLimit, libspatialindex_c), RTError, (IndexH, Int64), index, value)
+    @ccall libspatialindex_c.Index_SetResultSetLimit(index::IndexH, value::Int64)::RTError
 end
 
 function Index_GetResultSetLimit(index)
-    ccall((:Index_GetResultSetLimit, libspatialindex_c), Int64, (IndexH,), index)
+    @ccall libspatialindex_c.Index_GetResultSetLimit(index::IndexH)::Int64
 end
 
 function Index_DestroyObjResults(results, nResults)
-    ccall((:Index_DestroyObjResults, libspatialindex_c), Cvoid, (Ptr{IndexItemH}, UInt32), results, nResults)
+    @ccall libspatialindex_c.Index_DestroyObjResults(results::Ptr{IndexItemH}, nResults::UInt32)::Cvoid
 end
 
 function Index_ClearBuffer(index)
-    ccall((:Index_ClearBuffer, libspatialindex_c), Cvoid, (IndexH,), index)
+    @ccall libspatialindex_c.Index_ClearBuffer(index::IndexH)::Cvoid
 end
 
 function Index_Free(object)
-    ccall((:Index_Free, libspatialindex_c), Cvoid, (Ptr{Cvoid},), object)
+    @ccall libspatialindex_c.Index_Free(object::Ptr{Cvoid})::Cvoid
 end
 
 function Index_Flush(index)
-    ccall((:Index_Flush, libspatialindex_c), Cvoid, (IndexH,), index)
+    @ccall libspatialindex_c.Index_Flush(index::IndexH)::Cvoid
 end
 
 function IndexItem_Destroy(item)
-    ccall((:IndexItem_Destroy, libspatialindex_c), Cvoid, (IndexItemH,), item)
+    @ccall libspatialindex_c.IndexItem_Destroy(item::IndexItemH)::Cvoid
 end
 
 function IndexItem_GetID(item)
-    ccall((:IndexItem_GetID, libspatialindex_c), Int64, (IndexItemH,), item)
+    @ccall libspatialindex_c.IndexItem_GetID(item::IndexItemH)::Int64
 end
 
 function IndexItem_GetData(item, data, length)
-    ccall((:IndexItem_GetData, libspatialindex_c), RTError, (IndexItemH, Ptr{Ptr{UInt8}}, Ptr{UInt64}), item, data, length)
+    @ccall libspatialindex_c.IndexItem_GetData(item::IndexItemH, data::Ptr{Ptr{UInt8}}, length::Ptr{UInt64})::RTError
 end
 
 function IndexItem_GetBounds(item, ppdMin, ppdMax, nDimension)
-    ccall((:IndexItem_GetBounds, libspatialindex_c), RTError, (IndexItemH, Ptr{Ptr{Cdouble}}, Ptr{Ptr{Cdouble}}, Ptr{UInt32}), item, ppdMin, ppdMax, nDimension)
+    @ccall libspatialindex_c.IndexItem_GetBounds(item::IndexItemH, ppdMin::Ptr{Ptr{Cdouble}}, ppdMax::Ptr{Ptr{Cdouble}}, nDimension::Ptr{UInt32})::RTError
 end
 
 function IndexProperty_Create()
-    ccall((:IndexProperty_Create, libspatialindex_c), IndexPropertyH, ())
+    @ccall libspatialindex_c.IndexProperty_Create()::IndexPropertyH
 end
 
 function IndexProperty_Destroy(hProp)
-    ccall((:IndexProperty_Destroy, libspatialindex_c), Cvoid, (IndexPropertyH,), hProp)
+    @ccall libspatialindex_c.IndexProperty_Destroy(hProp::IndexPropertyH)::Cvoid
 end
 
 function IndexProperty_SetIndexType(iprop, value)
-    ccall((:IndexProperty_SetIndexType, libspatialindex_c), RTError, (IndexPropertyH, RTIndexType), iprop, value)
+    @ccall libspatialindex_c.IndexProperty_SetIndexType(iprop::IndexPropertyH, value::RTIndexType)::RTError
 end
 
 function IndexProperty_GetIndexType(iprop)
-    ccall((:IndexProperty_GetIndexType, libspatialindex_c), RTIndexType, (IndexPropertyH,), iprop)
+    @ccall libspatialindex_c.IndexProperty_GetIndexType(iprop::IndexPropertyH)::RTIndexType
 end
 
 function IndexProperty_SetDimension(iprop, value)
-    ccall((:IndexProperty_SetDimension, libspatialindex_c), RTError, (IndexPropertyH, UInt32), iprop, value)
+    @ccall libspatialindex_c.IndexProperty_SetDimension(iprop::IndexPropertyH, value::UInt32)::RTError
 end
 
 function IndexProperty_GetDimension(iprop)
-    ccall((:IndexProperty_GetDimension, libspatialindex_c), UInt32, (IndexPropertyH,), iprop)
+    @ccall libspatialindex_c.IndexProperty_GetDimension(iprop::IndexPropertyH)::UInt32
 end
 
 function IndexProperty_SetIndexVariant(iprop, value)
-    ccall((:IndexProperty_SetIndexVariant, libspatialindex_c), RTError, (IndexPropertyH, RTIndexVariant), iprop, value)
+    @ccall libspatialindex_c.IndexProperty_SetIndexVariant(iprop::IndexPropertyH, value::RTIndexVariant)::RTError
 end
 
 function IndexProperty_GetIndexVariant(iprop)
-    ccall((:IndexProperty_GetIndexVariant, libspatialindex_c), RTIndexVariant, (IndexPropertyH,), iprop)
+    @ccall libspatialindex_c.IndexProperty_GetIndexVariant(iprop::IndexPropertyH)::RTIndexVariant
 end
 
 function IndexProperty_SetIndexStorage(iprop, value)
-    ccall((:IndexProperty_SetIndexStorage, libspatialindex_c), RTError, (IndexPropertyH, RTStorageType), iprop, value)
+    @ccall libspatialindex_c.IndexProperty_SetIndexStorage(iprop::IndexPropertyH, value::RTStorageType)::RTError
 end
 
 function IndexProperty_GetIndexStorage(iprop)
-    ccall((:IndexProperty_GetIndexStorage, libspatialindex_c), RTStorageType, (IndexPropertyH,), iprop)
+    @ccall libspatialindex_c.IndexProperty_GetIndexStorage(iprop::IndexPropertyH)::RTStorageType
 end
 
 function IndexProperty_SetPagesize(iprop, value)
-    ccall((:IndexProperty_SetPagesize, libspatialindex_c), RTError, (IndexPropertyH, UInt32), iprop, value)
+    @ccall libspatialindex_c.IndexProperty_SetPagesize(iprop::IndexPropertyH, value::UInt32)::RTError
 end
 
 function IndexProperty_GetPagesize(iprop)
-    ccall((:IndexProperty_GetPagesize, libspatialindex_c), UInt32, (IndexPropertyH,), iprop)
+    @ccall libspatialindex_c.IndexProperty_GetPagesize(iprop::IndexPropertyH)::UInt32
 end
 
 function IndexProperty_SetIndexCapacity(iprop, value)
-    ccall((:IndexProperty_SetIndexCapacity, libspatialindex_c), RTError, (IndexPropertyH, UInt32), iprop, value)
+    @ccall libspatialindex_c.IndexProperty_SetIndexCapacity(iprop::IndexPropertyH, value::UInt32)::RTError
 end
 
 function IndexProperty_GetIndexCapacity(iprop)
-    ccall((:IndexProperty_GetIndexCapacity, libspatialindex_c), UInt32, (IndexPropertyH,), iprop)
+    @ccall libspatialindex_c.IndexProperty_GetIndexCapacity(iprop::IndexPropertyH)::UInt32
 end
 
 function IndexProperty_SetLeafCapacity(iprop, value)
-    ccall((:IndexProperty_SetLeafCapacity, libspatialindex_c), RTError, (IndexPropertyH, UInt32), iprop, value)
+    @ccall libspatialindex_c.IndexProperty_SetLeafCapacity(iprop::IndexPropertyH, value::UInt32)::RTError
 end
 
 function IndexProperty_GetLeafCapacity(iprop)
-    ccall((:IndexProperty_GetLeafCapacity, libspatialindex_c), UInt32, (IndexPropertyH,), iprop)
+    @ccall libspatialindex_c.IndexProperty_GetLeafCapacity(iprop::IndexPropertyH)::UInt32
 end
 
 function IndexProperty_SetLeafPoolCapacity(iprop, value)
-    ccall((:IndexProperty_SetLeafPoolCapacity, libspatialindex_c), RTError, (IndexPropertyH, UInt32), iprop, value)
+    @ccall libspatialindex_c.IndexProperty_SetLeafPoolCapacity(iprop::IndexPropertyH, value::UInt32)::RTError
 end
 
 function IndexProperty_GetLeafPoolCapacity(iprop)
-    ccall((:IndexProperty_GetLeafPoolCapacity, libspatialindex_c), UInt32, (IndexPropertyH,), iprop)
+    @ccall libspatialindex_c.IndexProperty_GetLeafPoolCapacity(iprop::IndexPropertyH)::UInt32
 end
 
 function IndexProperty_SetIndexPoolCapacity(iprop, value)
-    ccall((:IndexProperty_SetIndexPoolCapacity, libspatialindex_c), RTError, (IndexPropertyH, UInt32), iprop, value)
+    @ccall libspatialindex_c.IndexProperty_SetIndexPoolCapacity(iprop::IndexPropertyH, value::UInt32)::RTError
 end
 
 function IndexProperty_GetIndexPoolCapacity(iprop)
-    ccall((:IndexProperty_GetIndexPoolCapacity, libspatialindex_c), UInt32, (IndexPropertyH,), iprop)
+    @ccall libspatialindex_c.IndexProperty_GetIndexPoolCapacity(iprop::IndexPropertyH)::UInt32
 end
 
 function IndexProperty_SetRegionPoolCapacity(iprop, value)
-    ccall((:IndexProperty_SetRegionPoolCapacity, libspatialindex_c), RTError, (IndexPropertyH, UInt32), iprop, value)
+    @ccall libspatialindex_c.IndexProperty_SetRegionPoolCapacity(iprop::IndexPropertyH, value::UInt32)::RTError
 end
 
 function IndexProperty_GetRegionPoolCapacity(iprop)
-    ccall((:IndexProperty_GetRegionPoolCapacity, libspatialindex_c), UInt32, (IndexPropertyH,), iprop)
+    @ccall libspatialindex_c.IndexProperty_GetRegionPoolCapacity(iprop::IndexPropertyH)::UInt32
 end
 
 function IndexProperty_SetPointPoolCapacity(iprop, value)
-    ccall((:IndexProperty_SetPointPoolCapacity, libspatialindex_c), RTError, (IndexPropertyH, UInt32), iprop, value)
+    @ccall libspatialindex_c.IndexProperty_SetPointPoolCapacity(iprop::IndexPropertyH, value::UInt32)::RTError
 end
 
 function IndexProperty_GetPointPoolCapacity(iprop)
-    ccall((:IndexProperty_GetPointPoolCapacity, libspatialindex_c), UInt32, (IndexPropertyH,), iprop)
+    @ccall libspatialindex_c.IndexProperty_GetPointPoolCapacity(iprop::IndexPropertyH)::UInt32
 end
 
 function IndexProperty_SetBufferingCapacity(iprop, value)
-    ccall((:IndexProperty_SetBufferingCapacity, libspatialindex_c), RTError, (IndexPropertyH, UInt32), iprop, value)
+    @ccall libspatialindex_c.IndexProperty_SetBufferingCapacity(iprop::IndexPropertyH, value::UInt32)::RTError
 end
 
 function IndexProperty_GetBufferingCapacity(iprop)
-    ccall((:IndexProperty_GetBufferingCapacity, libspatialindex_c), UInt32, (IndexPropertyH,), iprop)
+    @ccall libspatialindex_c.IndexProperty_GetBufferingCapacity(iprop::IndexPropertyH)::UInt32
 end
 
 function IndexProperty_SetEnsureTightMBRs(iprop, value)
-    ccall((:IndexProperty_SetEnsureTightMBRs, libspatialindex_c), RTError, (IndexPropertyH, UInt32), iprop, value)
+    @ccall libspatialindex_c.IndexProperty_SetEnsureTightMBRs(iprop::IndexPropertyH, value::UInt32)::RTError
 end
 
 function IndexProperty_GetEnsureTightMBRs(iprop)
-    ccall((:IndexProperty_GetEnsureTightMBRs, libspatialindex_c), UInt32, (IndexPropertyH,), iprop)
+    @ccall libspatialindex_c.IndexProperty_GetEnsureTightMBRs(iprop::IndexPropertyH)::UInt32
 end
 
 function IndexProperty_SetOverwrite(iprop, value)
-    ccall((:IndexProperty_SetOverwrite, libspatialindex_c), RTError, (IndexPropertyH, UInt32), iprop, value)
+    @ccall libspatialindex_c.IndexProperty_SetOverwrite(iprop::IndexPropertyH, value::UInt32)::RTError
 end
 
 function IndexProperty_GetOverwrite(iprop)
-    ccall((:IndexProperty_GetOverwrite, libspatialindex_c), UInt32, (IndexPropertyH,), iprop)
+    @ccall libspatialindex_c.IndexProperty_GetOverwrite(iprop::IndexPropertyH)::UInt32
 end
 
 function IndexProperty_SetNearMinimumOverlapFactor(iprop, value)
-    ccall((:IndexProperty_SetNearMinimumOverlapFactor, libspatialindex_c), RTError, (IndexPropertyH, UInt32), iprop, value)
+    @ccall libspatialindex_c.IndexProperty_SetNearMinimumOverlapFactor(iprop::IndexPropertyH, value::UInt32)::RTError
 end
 
 function IndexProperty_GetNearMinimumOverlapFactor(iprop)
-    ccall((:IndexProperty_GetNearMinimumOverlapFactor, libspatialindex_c), UInt32, (IndexPropertyH,), iprop)
+    @ccall libspatialindex_c.IndexProperty_GetNearMinimumOverlapFactor(iprop::IndexPropertyH)::UInt32
 end
 
 function IndexProperty_SetWriteThrough(iprop, value)
-    ccall((:IndexProperty_SetWriteThrough, libspatialindex_c), RTError, (IndexPropertyH, UInt32), iprop, value)
+    @ccall libspatialindex_c.IndexProperty_SetWriteThrough(iprop::IndexPropertyH, value::UInt32)::RTError
 end
 
 function IndexProperty_GetWriteThrough(iprop)
-    ccall((:IndexProperty_GetWriteThrough, libspatialindex_c), UInt32, (IndexPropertyH,), iprop)
+    @ccall libspatialindex_c.IndexProperty_GetWriteThrough(iprop::IndexPropertyH)::UInt32
 end
 
 function IndexProperty_SetFillFactor(iprop, value)
-    ccall((:IndexProperty_SetFillFactor, libspatialindex_c), RTError, (IndexPropertyH, Cdouble), iprop, value)
+    @ccall libspatialindex_c.IndexProperty_SetFillFactor(iprop::IndexPropertyH, value::Cdouble)::RTError
 end
 
 function IndexProperty_GetFillFactor(iprop)
-    ccall((:IndexProperty_GetFillFactor, libspatialindex_c), Cdouble, (IndexPropertyH,), iprop)
+    @ccall libspatialindex_c.IndexProperty_GetFillFactor(iprop::IndexPropertyH)::Cdouble
 end
 
 function IndexProperty_SetSplitDistributionFactor(iprop, value)
-    ccall((:IndexProperty_SetSplitDistributionFactor, libspatialindex_c), RTError, (IndexPropertyH, Cdouble), iprop, value)
+    @ccall libspatialindex_c.IndexProperty_SetSplitDistributionFactor(iprop::IndexPropertyH, value::Cdouble)::RTError
 end
 
 function IndexProperty_GetSplitDistributionFactor(iprop)
-    ccall((:IndexProperty_GetSplitDistributionFactor, libspatialindex_c), Cdouble, (IndexPropertyH,), iprop)
+    @ccall libspatialindex_c.IndexProperty_GetSplitDistributionFactor(iprop::IndexPropertyH)::Cdouble
 end
 
 function IndexProperty_SetTPRHorizon(iprop, value)
-    ccall((:IndexProperty_SetTPRHorizon, libspatialindex_c), RTError, (IndexPropertyH, Cdouble), iprop, value)
+    @ccall libspatialindex_c.IndexProperty_SetTPRHorizon(iprop::IndexPropertyH, value::Cdouble)::RTError
 end
 
 function IndexProperty_GetTPRHorizon(iprop)
-    ccall((:IndexProperty_GetTPRHorizon, libspatialindex_c), Cdouble, (IndexPropertyH,), iprop)
+    @ccall libspatialindex_c.IndexProperty_GetTPRHorizon(iprop::IndexPropertyH)::Cdouble
 end
 
 function IndexProperty_SetReinsertFactor(iprop, value)
-    ccall((:IndexProperty_SetReinsertFactor, libspatialindex_c), RTError, (IndexPropertyH, Cdouble), iprop, value)
+    @ccall libspatialindex_c.IndexProperty_SetReinsertFactor(iprop::IndexPropertyH, value::Cdouble)::RTError
 end
 
 function IndexProperty_GetReinsertFactor(iprop)
-    ccall((:IndexProperty_GetReinsertFactor, libspatialindex_c), Cdouble, (IndexPropertyH,), iprop)
+    @ccall libspatialindex_c.IndexProperty_GetReinsertFactor(iprop::IndexPropertyH)::Cdouble
 end
 
 function IndexProperty_SetFileName(iprop, value)
-    ccall((:IndexProperty_SetFileName, libspatialindex_c), RTError, (IndexPropertyH, Cstring), iprop, value)
+    @ccall libspatialindex_c.IndexProperty_SetFileName(iprop::IndexPropertyH, value::Cstring)::RTError
 end
 
 function IndexProperty_GetFileName(iprop)
-    ccall((:IndexProperty_GetFileName, libspatialindex_c), Cstring, (IndexPropertyH,), iprop)
+    @ccall libspatialindex_c.IndexProperty_GetFileName(iprop::IndexPropertyH)::Cstring
 end
 
 function IndexProperty_SetFileNameExtensionDat(iprop, value)
-    ccall((:IndexProperty_SetFileNameExtensionDat, libspatialindex_c), RTError, (IndexPropertyH, Cstring), iprop, value)
+    @ccall libspatialindex_c.IndexProperty_SetFileNameExtensionDat(iprop::IndexPropertyH, value::Cstring)::RTError
 end
 
 function IndexProperty_GetFileNameExtensionDat(iprop)
-    ccall((:IndexProperty_GetFileNameExtensionDat, libspatialindex_c), Cstring, (IndexPropertyH,), iprop)
+    @ccall libspatialindex_c.IndexProperty_GetFileNameExtensionDat(iprop::IndexPropertyH)::Cstring
 end
 
 function IndexProperty_SetFileNameExtensionIdx(iprop, value)
-    ccall((:IndexProperty_SetFileNameExtensionIdx, libspatialindex_c), RTError, (IndexPropertyH, Cstring), iprop, value)
+    @ccall libspatialindex_c.IndexProperty_SetFileNameExtensionIdx(iprop::IndexPropertyH, value::Cstring)::RTError
 end
 
 function IndexProperty_GetFileNameExtensionIdx(iprop)
-    ccall((:IndexProperty_GetFileNameExtensionIdx, libspatialindex_c), Cstring, (IndexPropertyH,), iprop)
+    @ccall libspatialindex_c.IndexProperty_GetFileNameExtensionIdx(iprop::IndexPropertyH)::Cstring
 end
 
 function IndexProperty_SetCustomStorageCallbacksSize(iprop, value)
-    ccall((:IndexProperty_SetCustomStorageCallbacksSize, libspatialindex_c), RTError, (IndexPropertyH, UInt32), iprop, value)
+    @ccall libspatialindex_c.IndexProperty_SetCustomStorageCallbacksSize(iprop::IndexPropertyH, value::UInt32)::RTError
 end
 
 function IndexProperty_GetCustomStorageCallbacksSize(iprop)
-    ccall((:IndexProperty_GetCustomStorageCallbacksSize, libspatialindex_c), UInt32, (IndexPropertyH,), iprop)
+    @ccall libspatialindex_c.IndexProperty_GetCustomStorageCallbacksSize(iprop::IndexPropertyH)::UInt32
 end
 
 function IndexProperty_SetCustomStorageCallbacks(iprop, value)
-    ccall((:IndexProperty_SetCustomStorageCallbacks, libspatialindex_c), RTError, (IndexPropertyH, Ptr{Cvoid}), iprop, value)
+    @ccall libspatialindex_c.IndexProperty_SetCustomStorageCallbacks(iprop::IndexPropertyH, value::Ptr{Cvoid})::RTError
 end
 
 function IndexProperty_GetCustomStorageCallbacks(iprop)
-    ccall((:IndexProperty_GetCustomStorageCallbacks, libspatialindex_c), Ptr{Cvoid}, (IndexPropertyH,), iprop)
+    @ccall libspatialindex_c.IndexProperty_GetCustomStorageCallbacks(iprop::IndexPropertyH)::Ptr{Cvoid}
 end
 
 function IndexProperty_SetIndexID(iprop, value)
-    ccall((:IndexProperty_SetIndexID, libspatialindex_c), RTError, (IndexPropertyH, Int64), iprop, value)
+    @ccall libspatialindex_c.IndexProperty_SetIndexID(iprop::IndexPropertyH, value::Int64)::RTError
 end
 
 function IndexProperty_GetIndexID(iprop)
-    ccall((:IndexProperty_GetIndexID, libspatialindex_c), Int64, (IndexPropertyH,), iprop)
+    @ccall libspatialindex_c.IndexProperty_GetIndexID(iprop::IndexPropertyH)::Int64
 end
 
 function SIDX_NewBuffer(bytes)
-    ccall((:SIDX_NewBuffer, libspatialindex_c), Ptr{Cvoid}, (Cint,), bytes)
+    @ccall libspatialindex_c.SIDX_NewBuffer(bytes::Cint)::Ptr{Cvoid}
 end
 
 function SIDX_DeleteBuffer(buffer)
-    ccall((:SIDX_DeleteBuffer, libspatialindex_c), Cvoid, (Ptr{Cvoid},), buffer)
+    @ccall libspatialindex_c.SIDX_DeleteBuffer(buffer::Ptr{Cvoid})::Cvoid
 end
 
 function IndexProperty_SetResultSetLimit(iprop, value)
-    ccall((:IndexProperty_SetResultSetLimit, libspatialindex_c), RTError, (IndexPropertyH, UInt64), iprop, value)
+    @ccall libspatialindex_c.IndexProperty_SetResultSetLimit(iprop::IndexPropertyH, value::UInt64)::RTError
 end
 
 function IndexProperty_GetResultSetLimit(iprop)
-    ccall((:IndexProperty_GetResultSetLimit, libspatialindex_c), UInt64, (IndexPropertyH,), iprop)
+    @ccall libspatialindex_c.IndexProperty_GetResultSetLimit(iprop::IndexPropertyH)::UInt64
 end
 
 function SIDX_Version()
-    ccall((:SIDX_Version, libspatialindex_c), Cstring, ())
+    @ccall libspatialindex_c.SIDX_Version()::Cstring
 end
 
 function Error_GetLastErrorMsg()
-    ccall((:Error_GetLastErrorMsg, libspatialindex_c), Cstring, ())
+    @ccall libspatialindex_c.Error_GetLastErrorMsg()::Cstring
 end
 

--- a/src/include/sidx_config.jl
+++ b/src/include/sidx_config.jl
@@ -1,8 +1,41 @@
-@enum RTError::Int32 RT_None = 0 RT_Debug = 1 RT_Warning = 2 RT_Failure = 3 RT_Fatal = 4
-@enum RTIndexType::Int32 RT_RTree = 0 RT_MVRTree = 1 RT_TPRTree = 2 RT_InvalidIndexType = -99
-@enum RTStorageType::Int32 RT_Memory = 0 RT_Disk = 1 RT_Custom = 2 RT_InvalidStorageType = -99
-@enum RTIndexVariant::Int32 RT_Linear = 0 RT_Quadratic = 1 RT_Star = 2 RT_InvalidIndexVariant = -99
+const Tools_PropertySet = Cvoid
 
-IndexH = Ptr{Nothing}
-IndexItemH = Ptr{Nothing}
-IndexPropertyH = Ptr{Nothing}
+const IndexPropertyH = Ptr{Tools_PropertySet}
+
+const IndexS = Cvoid
+
+const IndexH = Ptr{IndexS}
+
+@enum RTError::UInt32 begin
+    RT_None = 0
+    RT_Debug = 1
+    RT_Warning = 2
+    RT_Failure = 3
+    RT_Fatal = 4
+end
+
+const SpatialIndex_IData = Cvoid
+
+const IndexItemH = Ptr{SpatialIndex_IData}
+
+@enum RTIndexType::Int32 begin
+    RT_RTree = 0
+    RT_MVRTree = 1
+    RT_TPRTree = 2
+    RT_InvalidIndexType = -99
+end
+
+@enum RTIndexVariant::Int32 begin
+    RT_Linear = 0
+    RT_Quadratic = 1
+    RT_Star = 2
+    RT_InvalidIndexVariant = -99
+end
+
+@enum RTStorageType::Int32 begin
+    RT_Memory = 0
+    RT_Disk = 1
+    RT_Custom = 2
+    RT_InvalidStorageType = -99
+end
+


### PR DESCRIPTION
- No strict typing anymore, as the old Integer type annotations were replaced with Int32/64, failing the tests.
- Add new methods from the 1.9 release (https://github.com/libspatialindex/libspatialindex/pull/154)
- ~~Pin the 1.9 jll release, so we don't automatically update to 1.10 (if that happens).~~ see #25