### PR TITLE
Add boundschecks to fix #35

### DIFF
--- a/src/LibSpatialIndex.jl
+++ b/src/LibSpatialIndex.jl
@@ -179,8 +179,10 @@ module LibSpatialIndex
             minvalues::Vector{Float64},
             maxvalues::Vector{Float64}
         )
+        length(minvalues) == rtree.ndim || throw(DimensionMismatch("Minimum values must have same length as RTree dimensions"))
+        length(maxvalues) == rtree.ndim || throw(DimensionMismatch("Maximum values must have same length as RTree dimensions"))
         C.Index_InsertData(rtree.index, Int64(id), pointer(minvalues),
-            pointer(maxvalues), UInt32(length(minvalues)), Ptr{UInt8}(0), Cint(0)
+            pointer(maxvalues), UInt32(rtree.ndim), Ptr{UInt8}(0), Cint(0)
         )
     end
     function insert!(rtree::RTree, id::Integer, extent::GI.Extent)
@@ -213,10 +215,13 @@ module LibSpatialIndex
             minvalues::Vector{Float64},
             maxvalues::Vector{Float64}
         )
+        length(minvalues) == rtree.ndim || throw(DimensionMismatch("Minimum values must have same length as RTree dimensions"))
+        length(maxvalues) == rtree.ndim || throw(DimensionMismatch("Maximum values must have same length as RTree dimensions"))
+        
         items = Ref{Ptr{Int64}}()
         nresults = Ref{UInt64}()
         result = C.Index_Intersects_id(rtree.index, pointer(minvalues),
-            pointer(maxvalues), UInt32(length(minvalues)), items, nresults
+            pointer(maxvalues), UInt32(rtree.ndim), items, nresults
         )
         _checkresult(result, "Index_Intersects_id: Failed to evaluate")
         unsafe_wrap(Array, items[], nresults[])
@@ -260,10 +265,13 @@ module LibSpatialIndex
             maxvalues::Vector{Float64},
             k::Integer
         )
+        length(minvalues) == rtree.ndim || throw(DimensionMismatch("Minimum values must have same length as RTree dimensions"))
+        length(maxvalues) == rtree.ndim || throw(DimensionMismatch("Maximum values must have same length as RTree dimensions"))
+
         items = Ref{Ptr{Int64}}()
         nresults = Ref{UInt64}(k)
         result = C.Index_NearestNeighbors_id(rtree.index, pointer(minvalues),
-            pointer(maxvalues), UInt32(length(minvalues)), items, nresults)
+            pointer(maxvalues), UInt32(rtree.ndim), items, nresults)
         _checkresult(result, "Index_NearestNeighbors_id: Failed to evaluate")
         unsafe_wrap(Array, items[], nresults[])
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -70,6 +70,23 @@ end
     @test sort(SI.knn(rtree, (2.0, 2.0), 1)) == [2]
 end
 
+@testset "Bounds checks" begin
+    # confirm that bounds checks on the Julia side are working
+    tree = SI.RTree(2)
+    @test_throws DimensionMismatch SI.insert!(tree, 0, [0.0], [0.0, 0.1])
+    @test_throws DimensionMismatch SI.insert!(tree, 0, [0.0, 1.0], [0.1])
+    # should throw even if they're the same length if they don't match dimensions
+    @test_throws DimensionMismatch SI.insert!(tree, 0, [0.0, 0.1, 1.1], [0.0, 0.1, 1.1])
+
+    @test_throws DimensionMismatch SI.intersects(tree, [0.0], [0.0, 0.1])
+    @test_throws DimensionMismatch SI.intersects(tree, [0.0, 1.0], [0.1])
+    @test_throws DimensionMismatch SI.intersects(tree, [0.0, 0.1, 1.1], [0.0, 0.1, 1.1])
+
+    @test_throws DimensionMismatch SI.knn(tree, [0.0], [0.0, 0.1], 1)
+    @test_throws DimensionMismatch SI.knn(tree, [0.0, 1.0], [0.1], 1)
+    @test_throws DimensionMismatch SI.knn(tree, [0.0, 0.1, 1.1], [0.0, 0.1, 1.1], 1)
+end
+
 @testset "Aqua" begin
     Aqua.test_all(LibSpatialIndex)
 end


### PR DESCRIPTION
Pretty much what the title says - for the three functions that take min and max values, confirm that both arrays are the same length as the RTree has dimensions. Add tests for same.

The MWE described in #35 now gives this output:

```
ERROR: DimensionMismatch: Minimum values must have same length as RTree dimensions
Stacktrace:
 [1] intersects(rtree::RTree, minvalues::Vector{Float64}, maxvalues::Vector{Float64})
   @ LibSpatialIndex ~/.julia/dev/LibSpatialIndex/src/LibSpatialIndex.jl:218
 [2] top-level scope
   @ REPL[9]:1
```

and if run at the REPL, returns you to the `julia>` prompt.