### PR TITLE
Updates after renaming default branch

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
     tags: '*'
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # LibSpatialIndex
 
 [![CI](https://github.com/JuliaGeo/LibSpatialIndex.jl/workflows/CI/badge.svg)](https://github.com/JuliaGeo/LibSpatialIndex.jl/actions?query=workflow%3ACI)
-[![Coverage Status](https://coveralls.io/repos/github/JuliaGeo/LibSpatialIndex.jl/badge.svg?branch=master&service=github)](https://coveralls.io/github/JuliaGeo/LibSpatialIndex.jl?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/JuliaGeo/LibSpatialIndex.jl/badge.svg?branch=main&service=github)](https://coveralls.io/github/JuliaGeo/LibSpatialIndex.jl?branch=main)
 
 LibSpatialIndex.jl is a julia wrapper around the C API of [libspatialindex](https://github.com/libspatialindex/libspatialindex), for spatially indexing kD bounding box data.  The Julia library (JLL) package is produced by the script at https://github.com/JuliaPackaging/Yggdrasil/tree/master/L/LibSpatialIndex and the resulting binary artifact is downloaded from https://github.com/JuliaBinaryWrappers/LibSpatialIndex_jll.jl.
 


### PR DESCRIPTION
Updates references from `master` to `main` after the default branch rename. This includes GitHub Actions workflow triggers and documentation URLs.

This PR was created with AI assistance.